### PR TITLE
Stop replacing deb.debian.org with Swedish mirror

### DIFF
--- a/docker/httpd/cnaas-setup.sh
+++ b/docker/httpd/cnaas-setup.sh
@@ -5,8 +5,6 @@ set -x
 
 export DEBIAN_FRONTEND noninteractive
 
-/bin/sed -i s/deb.debian.org/ftp.se.debian.org/g /etc/apt/sources.list
-
 apt-get update && \
     apt-get -y dist-upgrade && \
     apt-get install -y \


### PR DESCRIPTION
1. ftp.se.debian.org seems broken:
   > E: The repository 'http://ftp.se.debian.org/debian-security buster/updates Release' does not have a Release file.

2. Replacing `deb.debian.org` with explicit local mirrors is futile, since `deb.debian.org` is explicitly built to redirect to the geographically closest working mirror based on your source IP.