### PR TITLE
Let template repo branch be specified in environment

### DIFF
--- a/docker/httpd/http.sh
+++ b/docker/httpd/http.sh
@@ -7,7 +7,9 @@ then
 else
 	cd /opt/cnaas/www
 	rm -rf /opt/cnaas/www/templates
-	git clone $GITREPO_TEMPLATES templates
+        BRANCH=""
+        [ -n "$GITBRANCH_TEMPLATES" ] && BRANCH="-b $GITBRANCH_TEMPLATES"
+	git clone $BRANCH $GITREPO_TEMPLATES templates
 fi
 
 set -e


### PR DESCRIPTION
As GITREPO_TEMPLATES can be set in the environment, this also allows GITBRANCH_TEMPLATES to be set, to get a specific branch of the templates repo.

This in analogous to https://github.com/SUNET/cnaas-nms/pull/223 - but if we deploy CNaaS-NMS on another branch of the templates repo, we want the httpd server to use that same branch.
