### PR TITLE
Remove dev-requirements from requirements.txt

### DIFF
--- a/docker/httpd/Dockerfile
+++ b/docker/httpd/Dockerfile
@@ -19,7 +19,7 @@ RUN python3 -m venv /opt/cnaas/venv
 ENV PATH="/opt/cnaas/venv/bin:$PATH"
 
 WORKDIR /opt/cnaas
-COPY ../../requirements.txt .
+COPY requirements.txt .
 RUN pip install --upgrade pip && \
     pip install -r requirements.txt
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,2 +1,6 @@
-pytest==8.4.1
+-r requirements.txt
 httpx==0.28.1
+mypy-extensions==1.1.0
+mypy==1.15.0
+nose==1.3.7
+pytest==8.4.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 fastapi==0.116.1
-mypy-extensions==1.1.0
-mypy==1.15.0
-nose==1.3.7
 pydantic_core==2.33.2
 pydantic==2.11.7
 uvicorn==0.35.0


### PR DESCRIPTION
Move some additional dev-requirements from requirements.txt to further optimize the docker image size.
Gone down from: 392MB to: 293MB.

Fixed dockerfile requirements.txt context 